### PR TITLE
Fix rendering showmenu function

### DIFF
--- a/djgentelella/templatetags/gentelellamenu.py
+++ b/djgentelella/templatetags/gentelellamenu.py
@@ -52,10 +52,12 @@ def render_item(item, env={}, widget_list=[]):
     else:
         dev += format_html("""<a id="{}" href="{}" %s >{} {} </a> """%a_class,
                       'tm_'+str(item.id), get_link(item, env),  icon, get_title(item) )
+    if item.children.first():
+        dev += '<ul class="dropdown-menu " id="m_%d"  aria-labelledby="navbarDropdown" role="menu">'%(
+            item.pk)
     for node in item.children.all():
-        dev += '<ul class="dropdown-menu " id="m_%d_%d"  aria-labelledby="navbarDropdown" role="menu">'%(
-            item.pk, node.pk)
         dev += render_item(node, env=env, widget_list=widget_list)
+    if item.children.first():
         dev += '</ul>'
     dev += '</li>'
     return dev


### PR DESCRIPTION
This PR fix the render submenu function:

The reimplementation can be checked in the following file: `djgentelella/templatetags/gentelellamenu.py`.

The result is:
![photo_2020-12-05_17-24-31](https://user-images.githubusercontent.com/1195551/101267542-6b618880-371f-11eb-85df-384b4ddae3ed.jpg)

And the html generated is:
![Screenshot from 2020-12-05 13-09-19](https://user-images.githubusercontent.com/1195551/101267549-7a483b00-371f-11eb-9c95-663ea928a6bc.png)

And this fix the submenu rendering function.