### PR TITLE
Fix spellcheck support in TextareaWysiwyg

### DIFF
--- a/djgentelella/static/gentelella/js/widgets.js
+++ b/djgentelella/static/gentelella/js/widgets.js
@@ -220,8 +220,13 @@ document.gtwidgets = {
     },
     TextareaWysiwyg: function (instance) {
         $(instance).removeAttr('required');
+        var spellcheck = instance.attr('data-option-spellcheck') !== 'false';
+        var lang = instance.attr('data-option-lang') || 'en';
         instance.tinymce({
             menubar: false,
+            browser_spellcheck: spellcheck,
+            contextmenu: spellcheck ? false : 'link image table',
+            body_attrs: { lang: lang },
             toolbar: 'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent |  numlist bullist checklist | forecolor backcolor casechange permanentpen formatpainter removeformat | pagebreak | charmap emoticons | fullscreen  preview save print | insertfile image media pageembed template link anchor codesample | a11ycheck ltr rtl | showcomments addcomment',
             plugins: ['autolink', 'codesample', 'link', 'lists', 'media', 'quickbars', "advlist autolink lists link image charmap print preview anchor",
                 "searchreplace visualblocks code fullscreen", "insertdatetime media table paste imagetools wordcount",

--- a/djgentelella/widgets/wysiwyg.py
+++ b/djgentelella/widgets/wysiwyg.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.forms import Textarea
 from django.urls import reverse_lazy
+from django.utils.translation import get_language
 
 from djgentelella.widgets.core import update_kwargs
 
@@ -8,6 +10,9 @@ class TextareaWysiwyg(Textarea):
     template_name = 'gentelella/widgets/wysiwyg.html'
 
     def __init__(self, attrs=None, extraskwargs=True):
+        attrs = attrs or {}
+        attrs.setdefault("data-option-spellcheck", "true")
+        attrs.setdefault("data-option-lang", get_language() or settings.LANGUAGE_CODE)
         if extraskwargs:
             attrs = update_kwargs(attrs, self.__class__.__name__,
                                   base_class='wysiwyg form-control')


### PR DESCRIPTION
Enable browser spellcheck support in TextareaWysiwyg

1. Added data-option-spellcheck (default: true) and data-option-lan (default: en) 
2. Passed these options to TinyMCE (browser_spellcheck and body_attrs.lang)
3. Disabled TinyMCE context menu when spellcheck is enabled to allow native suggestions
